### PR TITLE
Puzzle overhaul

### DIFF
--- a/qrogue/game/logic/actors/__init__.py
+++ b/qrogue/game/logic/actors/__init__.py
@@ -1,5 +1,5 @@
 # exporting
-from .state_vector import StateVector
+from .state_vector import StateVector, CircuitMatrix
 from .controllables import Controllable, Player, Robot
 from .controllables import robot
 from .puzzles import Enemy, Boss, Riddle

--- a/qrogue/game/logic/actors/controllables/robot.py
+++ b/qrogue/game/logic/actors/controllables/robot.py
@@ -506,9 +506,6 @@ class TestBot(Robot):
         backpack = Backpack(5, gates)
 
         super(TestBot, self).__init__("Testbot", attributes, backpack, game_over_callback)
-    
-    def give_collectible(self, collectible: Collectible):
-        super(TestBot, self).give_collectible(collectible)
 
     def get_img(self):
         return "T"

--- a/qrogue/game/logic/actors/controllables/robot.py
+++ b/qrogue/game/logic/actors/controllables/robot.py
@@ -13,7 +13,7 @@ from qrogue.game.logic.actors.controllables import Controllable
 from qrogue.game.logic.actors.controllables.qubit import QubitSet, DummyQubitSet
 from qrogue.game.logic.collectibles import Coin, Collectible, Consumable, Instruction, Key, MultiCollectible, \
     Qubit, Energy
-from qrogue.util import CheatConfig, Config, Logger, InstructionConfig, GameplayConfig, QuantumSimulationConfig
+from qrogue.util import CheatConfig, Config, Logger, GameplayConfig, QuantumSimulationConfig
 
 
 # from jkq import ddsim
@@ -276,6 +276,7 @@ class Robot(Controllable, ABC):
         self.__simulator = StatevectorSimulator()#ddsim.JKQProvider().get_backend('statevector_simulator')
         self.__backend = Aer.get_backend('unitary_simulator')
         self.__stv = None
+        self.__circuit_matrix = None
         self.__qubit_indices = []
         for i in range(0, attributes.num_of_qubits):
             self.__qubit_indices.append(i)
@@ -351,13 +352,18 @@ class Robot(Controllable, ABC):
 
         job = execute(self.__circuit, self.__backend)
         result = job.result()
-        self.__circuit_matrix = CircuitMatrix(result.get_unitary(self.__circuit, decimals=QuantumSimulationConfig.DECIMALS))
+        self.__circuit_matrix = CircuitMatrix(result.get_unitary(self.__circuit,
+                                                                 decimals=QuantumSimulationConfig.DECIMALS))
 
     def __remove_instruction(self, instruction: Instruction, skip_qargs: bool = False):
         if instruction and instruction.is_used():
             self.__instructions[instruction.position] = None
             self.__instruction_count -= 1
             instruction.reset(skip_qargs=skip_qargs)
+
+    def remove_instruction(self, instruction: Instruction):
+        if instruction in self.__instructions:
+            self.__remove_instruction(instruction)
 
     def __place_instruction(self, instruction: Instruction, position: int):
         if instruction.position == position:

--- a/qrogue/game/logic/actors/controllables/robot.py
+++ b/qrogue/game/logic/actors/controllables/robot.py
@@ -3,7 +3,7 @@ Author: Artner Michael
 13.06.2021
 """
 from abc import ABC
-from typing import Tuple, List, Callable
+from typing import Tuple, List, Callable, Optional
 
 from qiskit import QuantumCircuit, transpile, Aer, execute
 from qiskit.providers.aer import StatevectorSimulator
@@ -468,9 +468,9 @@ class Robot(Controllable, ABC):
         """
         return self.__attributes.refill_energy(amount)
 
-    def get_circuit_print(self) -> str:
-        entry = "-" * (3 + InstructionConfig.MAX_ABBREVIATION_LEN + 3)
-        rows = [[entry] * self.circuit_space for _ in range(self.num_of_qubits)]
+    def gate_at(self, index: int) -> Optional[Instruction]:
+        if 0 <= index < self.circuit_space:
+            return self.__instructions[index]
 
         for i, inst in enumerate(self.__instructions):
             if inst:

--- a/qrogue/game/logic/actors/controllables/robot.py
+++ b/qrogue/game/logic/actors/controllables/robot.py
@@ -472,36 +472,6 @@ class Robot(Controllable, ABC):
         if 0 <= index < self.circuit_space:
             return self.__instructions[index]
 
-        for i, inst in enumerate(self.__instructions):
-            if inst:
-                for q in inst.qargs_iter():
-                    inst_str = inst.abbreviation(q)
-                    diff_len = InstructionConfig.MAX_ABBREVIATION_LEN - len(inst_str)
-                    inst_str = f"--{{{inst_str}}}--"
-                    if diff_len > 0:
-                        half_diff = int(diff_len / 2)
-                        inst_str = inst_str.ljust(len(inst_str) + half_diff, "-")
-                        if diff_len % 2 == 0:
-                            inst_str = inst_str.rjust(len(inst_str) + half_diff, "-")
-                        else:
-                            inst_str = inst_str.rjust(len(inst_str) + half_diff + 1, "-")
-                    rows[q][i] = inst_str
-
-        circ_str = " In "
-        # place qubits from top to bottom, high to low index
-        for q in range(len(rows) - 1, -1, -1):
-            circ_str += f"| q{q} >---"
-            row = rows[q]
-            for i in range(len(row)):
-                circ_str += row[i]
-                if i < len(row) - 1:
-                    circ_str += "+"
-            circ_str += f"< q'{q} |"
-            if q == len(rows) - 1:
-                circ_str += " Out "
-            circ_str += "\n"
-        return circ_str
-
 
 class TestBot(Robot):
     def __init__(self, game_over_callback: Callable[[], None], num_of_qubits: int = 2, gates: List[Instruction] = None):

--- a/qrogue/game/logic/actors/controllables/robot.py
+++ b/qrogue/game/logic/actors/controllables/robot.py
@@ -487,7 +487,7 @@ class Robot(Controllable, ABC):
                             inst_str = inst_str.rjust(len(inst_str) + half_diff + 1, "-")
                     rows[q][i] = inst_str
 
-        circ_str = ""
+        circ_str = " In "
         # place qubits from top to bottom, high to low index
         for q in range(len(rows) - 1, -1, -1):
             circ_str += f"| q{q} >---"
@@ -496,7 +496,10 @@ class Robot(Controllable, ABC):
                 circ_str += row[i]
                 if i < len(row) - 1:
                     circ_str += "+"
-            circ_str += "< out |\n"
+            circ_str += f"< q'{q} |"
+            if q == len(rows) - 1:
+                circ_str += " Out "
+            circ_str += "\n"
         return circ_str
 
 

--- a/qrogue/game/logic/actors/state_vector.py
+++ b/qrogue/game/logic/actors/state_vector.py
@@ -7,7 +7,7 @@ from qiskit.providers.aer import StatevectorSimulator
 
 from qrogue.game.logic.collectibles import Instruction
 from qrogue.util import Logger, QuantumSimulationConfig
-from qrogue.util.util_functions import is_power_of_2
+from qrogue.util.util_functions import is_power_of_2, center_string
 
 
 class StateVector:
@@ -158,11 +158,12 @@ class CircuitMatrix:
         self.__matrix = matrix
 
     def to_string(self) -> str:
-        text = "|"
+        text = "| "
         for row in self.__matrix:
             for val in row:
-                text += StateVector.complex_to_string(val)
-            text += "|\n|"
+                text += center_string(StateVector.complex_to_string(val), QuantumSimulationConfig.MAX_SPACE_PER_NUMBER)
+                text += " "
+            text += "|\n| "
         return text[:-1]    # remove the additional "|"
 
     def __str__(self) -> str:

--- a/qrogue/game/logic/actors/state_vector.py
+++ b/qrogue/game/logic/actors/state_vector.py
@@ -49,6 +49,14 @@ class StateVector:
         return text
 
     @staticmethod
+    def complex_to_amplitude_percentage_string(val: complex) -> str:
+        amp = np.round(abs(val**2), QuantumSimulationConfig.DECIMALS)
+        text = str(amp * 100)
+        if text[-2:] == ".0":
+            text = text[:-2]    # remove the redundant ".0"
+        return text + "%"
+
+    @staticmethod
     def create_zero_state_vector(num_of_qubits: int) -> "StateVector":
         amplitudes = [1] + [0] * (2**num_of_qubits - 1)
         return StateVector(amplitudes)
@@ -157,14 +165,22 @@ class CircuitMatrix:
     def __init__(self, matrix: List[List[complex]]):
         self.__matrix = matrix
 
+    @property
+    def size(self) -> int:
+        return len(self.__matrix)
+
+    @property
+    def num_of_qubits(self) -> int:
+        return int(np.log2(self.size))
+
     def to_string(self) -> str:
-        text = "| "
+        text = ""
         for row in self.__matrix:
             for val in row:
                 text += center_string(StateVector.complex_to_string(val), QuantumSimulationConfig.MAX_SPACE_PER_NUMBER)
                 text += " "
-            text += "|\n| "
-        return text[:-1]    # remove the additional "|"
+            text += "\n"
+        return text
 
     def __str__(self) -> str:
         text = "CircuitMatrix("

--- a/qrogue/game/logic/actors/state_vector.py
+++ b/qrogue/game/logic/actors/state_vector.py
@@ -6,19 +6,16 @@ from qiskit import transpile, QuantumCircuit
 from qiskit.providers.aer import StatevectorSimulator
 
 from qrogue.game.logic.collectibles import Instruction
-from qrogue.util import Logger
+from qrogue.util import Logger, QuantumSimulationConfig
 from qrogue.util.util_functions import is_power_of_2
 
 
 class StateVector:
-    __TOLERANCE = 0.1
-    __DECIMALS = 3
-
     @staticmethod
     def check_amplitudes(amplitudes: List[complex]):
         if is_power_of_2(len(amplitudes)):
             amp_sum = sum([c.real**2 + c.imag**2 for c in amplitudes])
-            return 1 - StateVector.__TOLERANCE <= amp_sum <= 1 + StateVector.__TOLERANCE
+            return 1 - QuantumSimulationConfig.TOLERANCE <= amp_sum <= 1 + QuantumSimulationConfig.TOLERANCE
         return False
 
     @staticmethod
@@ -34,7 +31,7 @@ class StateVector:
 
     @staticmethod
     def complex_to_string(val: complex) -> str:
-        val = np.round(val, StateVector.__DECIMALS)
+        val = np.round(val, QuantumSimulationConfig.DECIMALS)
         if val.imag == 0:
             text = f"{val.real:g}"  # g turns 0.0 to 0
         elif val.real == 0:
@@ -51,6 +48,11 @@ class StateVector:
             text = text[1:]
         return text
 
+    @staticmethod
+    def create_zero_state_vector(num_of_qubits: int) -> "StateVector":
+        amplitudes = [1] + [0] * (2**num_of_qubits - 1)
+        return StateVector(amplitudes)
+
     def __init__(self, amplitudes: List[complex]):
         self.__amplitudes = amplitudes
 
@@ -62,10 +64,21 @@ class StateVector:
     def num_of_qubits(self) -> int:
         return int(np.log2(self.size))
 
-    def to_value(self) -> List[float]:
-        return [np.round(val.real**2 + val.imag**2, decimals=StateVector.__DECIMALS) for val in self.__amplitudes]
+    @property
+    def is_zero(self) -> bool:
+        for val in self.__amplitudes:
+            if abs(val) > QuantumSimulationConfig.TOLERANCE:
+                return False
+        return True
 
-    def is_equal_to(self, other, tolerance: float = __TOLERANCE) -> bool:
+    def at(self, index: int) -> complex:
+        if 0 <= index < self.size:
+            return self.__amplitudes[index]
+
+    def to_value(self) -> List[float]:
+        return [np.round(val.real ** 2 + val.imag ** 2, decimals=QuantumSimulationConfig.DECIMALS) for val in self.__amplitudes]
+
+    def is_equal_to(self, other, tolerance: float = QuantumSimulationConfig.TOLERANCE) -> bool:
         if type(other) is not type(self):
             return False
         # other_value needs at least as many entries as self_value, more are allowed
@@ -84,7 +97,7 @@ class StateVector:
         """
         diff = [self.__amplitudes[i] - other.__amplitudes[i] for i in range(self.size)]
         for val in diff:
-            if abs(val) < -self.__TOLERANCE or self.__TOLERANCE < abs(val):
+            if abs(val) > tolerance:
                 return False
         return True
 
@@ -132,10 +145,31 @@ class StateVector:
     def __str__(self) -> str:
         text = "StateVector("
         for val in self.__amplitudes:
-            text += f"{np.round(val, StateVector.__DECIMALS)}, "
+            text += f"{np.round(val, QuantumSimulationConfig.DECIMALS)}, "
         text = text[:-2] + ")"
         return text
 
     def __iter__(self) -> Iterator:
         return iter(self.__amplitudes)
 
+
+class CircuitMatrix:
+    def __init__(self, matrix: List[List[complex]]):
+        self.__matrix = matrix
+
+    def to_string(self) -> str:
+        text = "|"
+        for row in self.__matrix:
+            for val in row:
+                text += StateVector.complex_to_string(val)
+            text += "|\n|"
+        return text[:-1]    # remove the additional "|"
+
+    def __str__(self) -> str:
+        text = "CircuitMatrix("
+        for row in self.__matrix:
+            for val in row:
+                text += f"{np.round(val, QuantumSimulationConfig.DECIMALS)}, "
+            text += "\n"
+        text = text[:-2] + ")"
+        return text

--- a/qrogue/game/logic/collectibles/instruction.py
+++ b/qrogue/game/logic/collectibles/instruction.py
@@ -74,6 +74,10 @@ class Instruction(Collectible, ABC):
     def qargs_iter(self) -> Iterator[int]:
         return iter(self._qargs)
 
+    def get_qubit_at(self, index: int = 0) -> int:
+        if 0 <= index < len(self._qargs):
+            return self._qargs[index]
+
     def name(self) -> str:
         return self.short_name() + " Gate"
 

--- a/qrogue/game/logic/collectibles/instruction.py
+++ b/qrogue/game/logic/collectibles/instruction.py
@@ -6,7 +6,7 @@ import qiskit.circuit.library.standard_gates as gates
 from qiskit import QuantumCircuit
 
 from qrogue.game.logic.collectibles import Collectible, CollectibleType
-from qrogue.util import ShopConfig
+from qrogue.util import ShopConfig, Logger
 
 
 class Instruction(Collectible, ABC):
@@ -32,6 +32,13 @@ class Instruction(Collectible, ABC):
     def position(self) -> int:
         return self.__position
 
+    @property
+    def no_qubits_specified(self) -> bool:
+        return len(self._qargs) <= 0
+
+    def can_use_qubit(self, qubit: int) -> bool:
+        return qubit not in self._qargs
+
     def use_qubit(self, qubit: int) -> bool:
         """
 
@@ -40,14 +47,20 @@ class Instruction(Collectible, ABC):
         """
         if len(self._qargs) >= self.__needed_qubits:
             return False
+        if not self.can_use_qubit(qubit):
+            Logger.instance().error("Cannot use the same qubit multiple times!")
+            return True
         self._qargs.append(qubit)
         return len(self._qargs) < self.__needed_qubits
 
     def is_used(self) -> bool:
         return self.__position >= 0
 
-    def use(self, position: int):
-        self.__position = position
+    def use(self, position: int) -> bool:
+        if len(self._qargs) == self.__needed_qubits:
+            self.__position = position
+            return True
+        return False
 
     def reset(self, skip_qargs: bool = False, skip_position: bool = False):
         if not skip_qargs:
@@ -200,10 +213,27 @@ class HGate(SingleQubitGate):
         return HGate()
 
 
+####### Multi Qubit Gates ########
+
+
+class MultiQubitGate(Instruction, ABC):
+    def abbreviation(self, qubit: int = 0):
+        if qubit in self._qargs:
+            index = self._qargs.index(qubit)
+        else:
+            # during placement we need an abbreviation for the next qubit
+            index = len(self._qargs)
+        return self._internal_abbreviation(index)
+
+    @abstractmethod
+    def _internal_abbreviation(self, index: int):
+        pass
+
+
 ####### Double Qubit Gates #######
 
 
-class DoubleQubitGate(Instruction, ABC):
+class DoubleQubitGate(MultiQubitGate, ABC):
     def __init__(self, instruction):
         super(DoubleQubitGate, self).__init__(instruction, needed_qubits=2)
 
@@ -218,11 +248,8 @@ class SwapGate(DoubleQubitGate):
     def short_name(self) -> str:
         return "Swap"
 
-    def abbreviation(self, qubit: int = 0):
-        if qubit == self._qargs[0]:
-            return " S0 "
-        else:
-            return " S1 "
+    def _internal_abbreviation(self, index: int):
+        return [" S1 ", " S0 "][index]
 
     def copy(self) -> "Instruction":
         return SwapGate()
@@ -235,11 +262,8 @@ class CXGate(DoubleQubitGate):
     def short_name(self) -> str:
         return "CX"
 
-    def abbreviation(self, qubit: int = 0):
-        if qubit == self._qargs[0]:
-            return " C "
-        else:
-            return " X "
+    def _internal_abbreviation(self, index: int):
+        return [" C ", " X "][index]
 
     def copy(self) -> "Instruction":
         return CXGate()

--- a/qrogue/game/world/map/spaceship_map.py
+++ b/qrogue/game/world/map/spaceship_map.py
@@ -5,14 +5,14 @@ from qrogue.game.logic.actors import Robot, Controllable, Player
 from qrogue.game.world.navigation import Direction, Coordinate
 from qrogue.game.world.tiles import Tile, TileCode, WalkTriggerTile
 from qrogue.game.world.tiles.tiles import NpcTile
-from qrogue.util import Config, MapConfig, achievements, RandomManager
+from qrogue.util import Config, MapConfig, achievements
 
 SCIENTIST_TILE_REPRESENTATION = Config.scientist_name()[0]
 ascii_spaceship = \
     r"                                                                                              " + "\n" \
     r"                                    X---------------X                                         " + "\n" \
     r"                                   /ööööööööööööööööö)>                                       " + "\n" \
-    r"                                  /öööööööBöööööööööö)>                           /)          " + "\n" \
+    r"                                  /öTöööööBöööööööööö)>                           /)          " + "\n" \
     r"                                 /ööööööööööööööööööö)>                          /ö|          " + "\n" \
     r"                                |öööööööööööööööööööö)>                         /öö|          " + "\n" \
     r"                                |öööööööööööööööööööö)>                        /ööö|          " + "\n" \
@@ -96,6 +96,7 @@ class SpaceshipTriggerTile(WalkTriggerTile):
     MAP_WORKBENCH_REPRESENTATION = "W"
     MAP_GATE_LIBRARY_REPRESENTATION = "G"
     QUICKSTART_LEVEL = "Q"      # Quickstart
+    TRAININGS_ROOM = "T"
 
     def __init__(self, character: str, callback: Callable[[Direction, Robot], None]):
         super().__init__(TileCode.SpaceshipTrigger)
@@ -146,11 +147,11 @@ class SpaceshipMap:
     HEIGHT = ascii_spaceship.count("\n")
     SPAWN_POS = Coordinate(x=25, y=16)
 
-    def __init__(self, seed: int, player: Player, scientist: NpcTile, check_achievement: Callable[[str], bool],
+    def __init__(self, player: Player, scientist: NpcTile, check_achievement: Callable[[str], bool],
                  stop_playing: Callable[[Direction, Controllable], None],
                  open_world_view: Callable[[Direction, Controllable], None],
                  use_workbench: Callable[[Direction, Controllable], None],
-                 load_map: Callable[[str, Coordinate], None]):
+                 load_map: Callable[[str, Coordinate], None], start_training: Callable[[Direction], None]):
         self.__player = player
         self.__scientist = scientist
         self.__check_achievement = check_achievement
@@ -158,6 +159,7 @@ class SpaceshipMap:
         self.__open_world_view = open_world_view
         self.__use_workbench_callback = use_workbench
         self.__load_map = load_map
+        self.__start_training = start_training
         self.__tiles = []
         row = []
         for character in ascii_spaceship:
@@ -205,6 +207,10 @@ class SpaceshipMap:
                 def start_newest_level(direction: Direction, controllable: Controllable):
                     self.__load_map(MapConfig.spaceship(), None)
                 tile = SpaceshipTriggerTile(character, start_newest_level)
+        elif character == SpaceshipTriggerTile.TRAININGS_ROOM:
+            def start_training(direction: Direction, controllable: Controllable):
+                self.__start_training(direction)
+            tile = SpaceshipTriggerTile(character, start_training)
         else:
             tile = SpaceshipWallTile(character)
         return tile

--- a/qrogue/graphics/widgets/__init__.py
+++ b/qrogue/graphics/widgets/__init__.py
@@ -3,7 +3,7 @@ from .renderable import Renderable
 from .my_widgets import MyBaseWidget, Widget
 from .widget_sets import MyWidgetSet
 from .widget_sets import ExploreWidgetSet, NavigationWidgetSet
-from .widget_sets import FightWidgetSet, BossFightWidgetSet, RiddleWidgetSet
+from .widget_sets import ReachTargetWidgetSet, TrainingsWidgetSet, FightWidgetSet, BossFightWidgetSet, RiddleWidgetSet
 from .widget_sets import MenuWidgetSet, PauseMenuWidgetSet, ShopWidgetSet, WorkbenchWidgetSet
 from .spaceship import SpaceshipWidgetSet
 

--- a/qrogue/graphics/widgets/my_widgets.py
+++ b/qrogue/graphics/widgets/my_widgets.py
@@ -395,6 +395,27 @@ class StateVectorWidget(Widget):
         self.widget.set_title("")
 
 
+class InputStateVectorWidget(StateVectorWidget):
+    def __init__(self, widget: WidgetWrapper, headline: str):
+        super().__init__(widget, headline)
+
+    def set_data(self, state_vector: StateVector) -> None:
+        rows = [""] * state_vector.size
+        for i in range(state_vector.size):
+            rows[i] = center_string(StateVector.complex_to_string(state_vector.at(i)),
+                                    QuantumSimulationConfig.MAX_SPACE_PER_NUMBER)
+            rows[i] = f"|{to_binary_string(i, state_vector.num_of_qubits)}>  {rows[i]}"
+        max_row_len = max([len(row) for row in rows])
+        rows = [align_string(row, max_row_len) for row in rows]
+
+        text = "|"
+        for i in range(state_vector.num_of_qubits - 1, -1, -1):
+            text += f"q{i}"
+        text += ">"
+
+        self._stv_str_rep = f"~{text}  {self._headline}~\n" + "\n".join(rows)
+
+
 class OutputStateVectorWidget(StateVectorWidget):
     def __init__(self, widget: WidgetWrapper, headline: str):
         super().__init__(widget, headline)

--- a/qrogue/graphics/widgets/my_widgets.py
+++ b/qrogue/graphics/widgets/my_widgets.py
@@ -551,7 +551,7 @@ class SelectionWidget(Widget):
         self.__choices = []
         self.__callbacks = []
 
-    def set_data(self, data: "tuple of list of str and list of SelectionCallbacks") -> None:
+    def set_data(self, data: "Tuple[List[str], List[Callable]]") -> None:
         self.render_reset()
         self.__choices, self.__callbacks = data
         choice_length = 0

--- a/qrogue/graphics/widgets/my_widgets.py
+++ b/qrogue/graphics/widgets/my_widgets.py
@@ -229,7 +229,7 @@ class CircuitWidget(Widget):
                     self.__place_holder_data = gate, pos, qubit-1
                 else:
                     self.__place_holder_data = gate, pos, qubit+1
-                    self.render()
+                self.render()
                 return False
             if self.__robot.use_instruction(gate, pos):
                 self.__place_holder_data = None

--- a/qrogue/graphics/widgets/my_widgets.py
+++ b/qrogue/graphics/widgets/my_widgets.py
@@ -451,11 +451,10 @@ class SelectionWidget(Widget):
         self.widget.add_text_color_rule(f"->", ColorConfig.SELECTION_COLOR, 'contains', match_type='regex')
 
         # init keys
-        self.widget.add_key_command(controls.get_keys(Keys.SelectionUp), self.up)
-        self.widget.add_key_command(controls.get_keys(Keys.SelectionUp), self.up)
-        self.widget.add_key_command(controls.get_keys(Keys.SelectionRight), self.right)
-        self.widget.add_key_command(controls.get_keys(Keys.SelectionDown), self.down)
-        self.widget.add_key_command(controls.get_keys(Keys.SelectionLeft), self.left)
+        self.widget.add_key_command(controls.get_keys(Keys.SelectionUp), self.__up)
+        self.widget.add_key_command(controls.get_keys(Keys.SelectionRight), self.__right)
+        self.widget.add_key_command(controls.get_keys(Keys.SelectionDown), self.__down)
+        self.widget.add_key_command(controls.get_keys(Keys.SelectionLeft), self.__left)
 
         # sadly cannot use a loop here because of how lambda expressions work the index would be the same for all calls
         # instead we use a list of indices to still be flexible without changing much code

--- a/qrogue/graphics/widgets/my_widgets.py
+++ b/qrogue/graphics/widgets/my_widgets.py
@@ -291,10 +291,10 @@ class CircuitWidget(Widget):
                         rows[q][pos] = f"--{{{gate.abbreviation(q)}}}--"
                     rows[qubit][pos] = f"-- {gate.abbreviation(qubit)} --"
 
-            circ_str = " In "
+            circ_str = " In "   # for some reason the whitespace in front is needed to center the text correctly
             # place qubits from top to bottom, high to low index
             for q in range(len(rows) - 1, -1, -1):
-                circ_str += f"| q{q} >---"
+                circ_str += f"| q{q} >"
                 row = rows[q]
                 for i in range(len(row)):
                     circ_str += row[i]
@@ -302,7 +302,7 @@ class CircuitWidget(Widget):
                         circ_str += "+"
                 circ_str += f"< q'{q} |"
                 if q == len(rows) - 1:
-                    circ_str += " Out "
+                    circ_str += " Out"
                 circ_str += "\n"
 
             self.widget.set_title(circ_str)

--- a/qrogue/graphics/widgets/spaceship.py
+++ b/qrogue/graphics/widgets/spaceship.py
@@ -44,9 +44,8 @@ class SpaceshipWidget(Widget):
 class SpaceshipWidgetSet(MyWidgetSet):
     def __init__(self, controls: Controls, logger, root: py_cui.PyCUI,
                  base_render_callback: Callable[[List[Renderable]], None]):
-        super().__init__(controls, logger, root, base_render_callback)
+        super().__init__(logger, root, base_render_callback)
 
-    def init_widgets(self, controls: Controls) -> None:
         spaceship = self.add_block_label("Dynamic Spaceship", 0, 0, UIConfig.WINDOW_HEIGHT, UIConfig.WINDOW_WIDTH,
                                          center=True)
         spaceship.add_key_command(controls.get_keys(Keys.MoveUp), self.move_up)

--- a/qrogue/graphics/widgets/spaceship.py
+++ b/qrogue/graphics/widgets/spaceship.py
@@ -5,7 +5,7 @@ import py_cui
 from qrogue.game.world.map import SpaceshipMap
 from qrogue.game.world.navigation import Direction
 from qrogue.graphics.rendering import ColorRules
-from qrogue.util import Controls, Keys
+from qrogue.util import Controls, Keys, UIConfig
 
 from qrogue.graphics.widgets import MyBaseWidget, MyWidgetSet, Renderable, Widget
 
@@ -47,7 +47,7 @@ class SpaceshipWidgetSet(MyWidgetSet):
         super().__init__(controls, logger, root, base_render_callback)
 
     def init_widgets(self, controls: Controls) -> None:
-        spaceship = self.add_block_label("Dynamic Spaceship", 0, 0, MyWidgetSet.NUM_OF_ROWS, MyWidgetSet.NUM_OF_COLS,
+        spaceship = self.add_block_label("Dynamic Spaceship", 0, 0, UIConfig.WINDOW_HEIGHT, UIConfig.WINDOW_WIDTH,
                                          center=True)
         spaceship.add_key_command(controls.get_keys(Keys.MoveUp), self.move_up)
         spaceship.add_key_command(controls.get_keys(Keys.MoveRight), self.move_right)

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -29,62 +29,47 @@ class MyWidgetSet(WidgetSet, Renderable, ABC):
 
     BACK_STRING = "-Back-"
 
-    def __init__(self, controls: Controls, logger, root: py_cui.PyCUI,
-                 base_render_callback: Callable[[List[Renderable]], None]):
+    def __init__(self, logger, root: py_cui.PyCUI, base_render_callback: Callable[[List[Renderable]], None]):
         super().__init__(UIConfig.WINDOW_HEIGHT, UIConfig.WINDOW_WIDTH, logger, root)
-        self.init_widgets(controls)
         self.__base_render = base_render_callback
 
     def add_block_label(self, title, row, column, row_span=1, column_span=1, padx=1, pady=0, center=True)\
             -> MyBaseWidget:
         """Function that adds a new block label to the CUI grid
 
-                Parameters
-                ----------
-                title : str
-                    The title of the block label
-                row : int
-                    The row value, from the top down
-                column : int
-                    The column value from the top down
-                row_span=1 : int
-                    The number of rows to span accross
-                column_span=1 : int
-                    the number of columns to span accross
-                padx=1 : int
-                    number of padding characters in the x direction
-                pady=0 : int
-                    number of padding characters in the y direction
-                center : bool
-                    flag to tell label to be centered or left-aligned.
+        Parameters
+        ----------
+        title : str
+            The title of the block label
+        row : int
+            The row value, from the top down
+        column : int
+            The column value from the top down
+        row_span : int
+            The number of rows to span across
+        column_span : int
+            the number of columns to span across
+        padx : int
+            number of padding characters in the x direction
+        pady : int
+            number of padding characters in the y direction
+        center : bool
+            flag to tell label to be centered or left-aligned.
 
-                Returns
-                -------
-                new_widget : MyBaseWidget
-                    A reference to the created widget object.
-                """
+        Returns
+        -------
+        new_widget : MyBaseWidget
+            A reference to the created widget object.
+        """
         wid = 'Widget{}'.format(len(self._widgets.keys()))
-        new_widget = MyBaseWidget(wid,
-                                       title,
-                                       self._grid,
-                                       row,
-                                       column,
-                                       row_span,
-                                       column_span,
-                                       padx,
-                                       pady,
-                                       center,
-                                       self._logger)
+        new_widget = MyBaseWidget(wid, title, self._grid, row, column, row_span, column_span, padx, pady, center,
+                                  self._logger)
         self._widgets[wid] = new_widget
         self._logger.info('Adding widget {} w/ ID {} of type {}'.format(title, id, str(type(new_widget))))
         return new_widget
 
     def render(self) -> None:
         self.__base_render(self.get_widget_list())
-
-    @abstractmethod
-    def init_widgets(self, controls: Controls) -> None:
-        pass
 
     @abstractmethod
     def get_widget_list(self) -> List[Widget]:
@@ -130,9 +115,8 @@ class MenuWidgetSet(MyWidgetSet):
         self.__start_playing = start_playing_callback
         self.__stop = stop_callback
         self.__choose_simulation = choose_simulation_callback
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
 
-    def init_widgets(self, controls: Controls) -> None:
         width = UIConfig.WINDOW_WIDTH - UIConfig.ASCII_ART_WIDTH
         selection = self.add_block_label("", UIConfig.MAIN_MENU_ROW, 0, row_span=UIConfig.MAIN_MENU_HEIGHT,
                                          column_span=width, center=True)
@@ -206,13 +190,12 @@ class PauseMenuWidgetSet(MyWidgetSet):
     def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI,
                  continue_callback: Callable[[], None], save_callback: Callable[[], CommonPopups],
                  exit_run_callback: Callable[[], None]):
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
         self.__continue_callback = continue_callback
         self.__save_callback = save_callback
         self.__exit_run = exit_run_callback
         self.__achievement_manager = None
 
-    def init_widgets(self, controls: Controls) -> None:
         hud = self.add_block_label('HUD', 0, 0, row_span=UIConfig.HUD_HEIGHT, column_span=UIConfig.WINDOW_WIDTH,
                                    center=False)
         hud.toggle_border()
@@ -265,7 +248,8 @@ class PauseMenuWidgetSet(MyWidgetSet):
 
     def __help_text(self, index: int = 0) -> bool:
         if index < len(PauseMenuWidgetSet.__HELP_TEXTS[0]):
-            Popup.generic_info(f"{PauseMenuWidgetSet.__HELP_TEXTS[0][index]}", PauseMenuWidgetSet.__HELP_TEXTS[1][index])
+            Popup.generic_info(f"{PauseMenuWidgetSet.__HELP_TEXTS[0][index]}",
+                               PauseMenuWidgetSet.__HELP_TEXTS[1][index])
             return False
         return True
 
@@ -320,9 +304,8 @@ class WorkbenchWidgetSet(MyWidgetSet):
                  render: Callable[[List[Renderable]], None], continue_callback: Callable[[], None]):
         self.__continue = continue_callback
         self.__available_robots = available_robots
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
 
-    def init_widgets(self, controls: Controls) -> None:
         robot_selection = self.add_block_label('Robot Selection', 0, 0, row_span=UIConfig.WINDOW_HEIGHT, center=False)
         self.__robot_selection = SelectionWidget(robot_selection, controls, stay_selected=True)
         self.__robot_selection.set_data((
@@ -334,7 +317,8 @@ class WorkbenchWidgetSet(MyWidgetSet):
         self.__robot_info = SimpleWidget(robot_details)
 
         available_upgrades = self.add_block_label('Upgrades', 4, 1, 2, 2, center=True)
-        self.__available_upgrades = SelectionWidget(available_upgrades, controls, 4, is_second=True, stay_selected=False)
+        self.__available_upgrades = SelectionWidget(available_upgrades, controls, 4, is_second=True,
+                                                    stay_selected=False)
 
         # init action key commands
         def use_selection():
@@ -382,9 +366,8 @@ class WorkbenchWidgetSet(MyWidgetSet):
 
 class ExploreWidgetSet(MyWidgetSet):
     def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI):
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
 
-    def init_widgets(self, controls: Controls) -> None:
         hud = self.add_block_label('HUD', 0, 0, row_span=UIConfig.HUD_HEIGHT, column_span=UIConfig.WINDOW_WIDTH,
                                    center=False)
         hud.toggle_border()
@@ -448,10 +431,8 @@ class ExploreWidgetSet(MyWidgetSet):
 class NavigationWidgetSet(MyWidgetSet):
     def __init__(self, controls: Controls, logger, root: py_cui.PyCUI,
                  base_render_callback: Callable[[List[Renderable]], None]):
+        super().__init__(logger, root, base_render_callback)
 
-        super().__init__(controls, logger, root, base_render_callback)
-
-    def init_widgets(self, controls: Controls) -> None:
         map_widget = self.add_block_label('MAP', UIConfig.HUD_HEIGHT, 0, row_span=UIConfig.NON_HUD_HEIGHT,
                                           column_span=UIConfig.WINDOW_WIDTH, center=True)
         self.__map_widget = MapWidget(map_widget)
@@ -487,9 +468,7 @@ class NavigationWidgetSet(MyWidgetSet):
         self.__map_widget.set_data(map_)
 
     def get_widget_list(self) -> List[Widget]:
-        return [
-            self.__map_widget
-        ]
+        return [self.__map_widget]
 
     def reset(self) -> None:
         self.__map_widget.render_reset()
@@ -503,7 +482,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
                  continue_exploration_callback: Callable[[], None], flee_choice: str = "Flee"):
         self.__choice_strings = SelectionWidget.wrap_in_hotkey_str(["Add/Remove", "Reset", "Help",
                                                                     flee_choice])
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
         self._continue_exploration_callback = continue_exploration_callback
         self._robot = None
         self._target = None
@@ -511,7 +490,6 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         self.__num_of_qubits = -1   # needs to be an illegal value because we definitely want to reposition all
         # dependent widgets for the first usage of this WidgetSet
 
-    def init_widgets(self, controls: Controls) -> None:
         posy = 0
         posx = 0
         row_span = UIConfig.stv_height(2)   # doesn't matter since we reposition the dependent widgets anyway
@@ -743,7 +721,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         else:
             options = [f"Position {i}" for i in range(self._robot.circuit_space)] + ["Remove"]
             self._details.set_data(data=(
-                SelectionWidget.wrap_in_hotkey_str(options),# + [MyWidgetSet.BACK_STRING],
+                SelectionWidget.wrap_in_hotkey_str(options),  # + [MyWidgetSet.BACK_STRING],
                 [self.__choose_position]
             ))
         self.render()
@@ -776,8 +754,8 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
                 [f"Congratulations! You received: {reward.to_string()}"],
                 [self._continue_exploration_callback]
             ))
-            #Popup.generic_info("Congratulations!", f"You received: {reward.to_string()}")
-            #self._continue_exploration_callback()
+            # Popup.generic_info("Congratulations!", f"You received: {reward.to_string()}")
+            # self._continue_exploration_callback()
             return True
         else:
             return self._on_commit_fail()
@@ -955,12 +933,11 @@ class BossFightWidgetSet(FightWidgetSet):
 class ShopWidgetSet(MyWidgetSet):
     def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI,
                  continue_exploration_callback: Callable[[], None]):
-        super().__init__(controls, logger, root, render)
+        super().__init__(logger, root, render)
         self.__continue_exploration = continue_exploration_callback
         self.__robot = None
         self.__items = None
 
-    def init_widgets(self, controls: Controls) -> None:
         hud = self.add_block_label("HUD", 0, 0, row_span=UIConfig.HUD_HEIGHT, column_span=UIConfig.WINDOW_WIDTH,
                                    center=False)
         self.__hud = HudWidget(hud)

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -19,7 +19,7 @@ from qrogue.util import CommonPopups, Config, Controls, GameplayConfig, HelpText
 
 from qrogue.graphics.widgets import Renderable
 from qrogue.graphics.widgets.my_widgets import SelectionWidget, CircuitWidget, MapWidget, SimpleWidget, HudWidget, \
-    MyBaseWidget, Widget, OutputStateVectorWidget, StateVectorWidget, CircuitMatrixWidget, TargetStateVectorWidget
+    MyBaseWidget, Widget, OutputStateVectorWidget, CircuitMatrixWidget, TargetStateVectorWidget, InputStateVectorWidget
 
 
 class MyWidgetSet(WidgetSet, Renderable, ABC):
@@ -504,7 +504,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         posy += UIConfig.HUD_HEIGHT
 
         stv = self.add_block_label('Input StV', posy, posx, row_span, UIConfig.INPUT_STV_WIDTH, center=True)
-        self.__input_stv = StateVectorWidget(stv, "In^T")
+        self.__input_stv = InputStateVectorWidget(stv, "In^T")
         posx += UIConfig.INPUT_STV_WIDTH
 
         multiplication = self.add_block_label('Mul sign', posy, posx, row_span, column_span=1, center=True)

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -489,7 +489,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
 
     def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI,
                  continue_exploration_callback: "()", flee_choice: str = "Flee"):
-        self.__choice_strings = SelectionWidget.wrap_in_hotkey_str(["Add/Remove", "Commit", "Reset", "Items", "Help",
+        self.__choice_strings = SelectionWidget.wrap_in_hotkey_str(["Add/Remove", "Reset", "Help",
                                                                     flee_choice])
         super().__init__(controls, logger, root, render)
         self._continue_exploration_callback = continue_exploration_callback
@@ -518,8 +518,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         self._choices = SelectionWidget(choices, controls, columns=self.__CHOICE_COLUMNS)
         self._choices.set_data(data=(
             self.__choice_strings,
-            [self.__choices_adapt, self.__choices_commit, self.__choices_reset, self.__choices_items,
-             self.__choices_help, self._choices_flee]
+            [self.__choices_adapt, self.__choices_reset, self.__choices_help, self._choices_flee]
         ))
 
         details = self.add_block_label('Details', 7, 3, row_span=2, column_span=6, center=True)
@@ -643,6 +642,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
             SelectionWidget.wrap_in_hotkey_str(options) + [MyWidgetSet.BACK_STRING],
             [self.__choose_instruction]
         ))
+        self.__choices_commit()     # immediately commit on change
         self.render()
         return False
 

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -19,7 +19,7 @@ from qrogue.util import CommonPopups, Config, Controls, GameplayConfig, HelpText
 
 from qrogue.graphics.widgets import Renderable
 from qrogue.graphics.widgets.my_widgets import SelectionWidget, CircuitWidget, MapWidget, SimpleWidget, HudWidget, \
-    MyBaseWidget, Widget, CurrentStateVectorWidget, StateVectorWidget, CircuitMatrixWidget
+    MyBaseWidget, Widget, CurrentStateVectorWidget, StateVectorWidget, CircuitMatrixWidget, TargetStateVectorWidget
 
 
 class MyWidgetSet(WidgetSet, Renderable, ABC):
@@ -524,7 +524,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         self.__eq_widget = SimpleWidget(equality)
 
         stv = self.add_block_label('Target StV', stv_row, 8, row_span=row_span, column_span=1, center=True)
-        self.__stv_target = StateVectorWidget(stv, "Target State")
+        self.__stv_target = TargetStateVectorWidget(stv, "Target State")
 
 
 

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -795,6 +795,22 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         pass
 
 
+class TrainingsWidgetSet(ReachTargetWidgetSet):
+    def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI,
+                 back_to_spaceship_callback: Callable[[], None]):
+        super().__init__(controls, render, logger, root, back_to_spaceship_callback)
+
+    def _on_commit_fail(self) -> bool:
+        return True
+
+    def _choices_flee(self) -> bool:
+        self._details.set_data(data=(
+            ["You return to the Spaceship!"],
+            [self._continue_exploration_callback]
+        ))
+        return True
+
+
 class FightWidgetSet(ReachTargetWidgetSet):
     def __init__(self, controls: Controls, render: Callable[[List[Renderable]], None], logger, root: py_cui.PyCUI,
                  continue_exploration_callback: Callable[[], None], game_over_callback: Callable[[], None]):

--- a/qrogue/graphics/widgets/widget_sets.py
+++ b/qrogue/graphics/widgets/widget_sets.py
@@ -521,7 +521,7 @@ class ReachTargetWidgetSet(MyWidgetSet, ABC):
         posx += 1
 
         stv = self.add_block_label('Output StV', posy, posx, row_span, UIConfig.OUTPUT_STV_WIDTH, center=True)
-        self.__stv_robot = OutputStateVectorWidget(stv, "Out")
+        self.__stv_robot = OutputStateVectorWidget(stv, "Out^T")
         posx += UIConfig.OUTPUT_STV_WIDTH
 
         equality = self.add_block_label('Eq sign', posy, posx, row_span, column_span=1, center=True)

--- a/qrogue/management/qrogue_pycui.py
+++ b/qrogue/management/qrogue_pycui.py
@@ -19,7 +19,7 @@ from qrogue.graphics.widgets import Renderable, SpaceshipWidgetSet, BossFightWid
     FightWidgetSet, MenuWidgetSet, MyWidgetSet, NavigationWidgetSet, PauseMenuWidgetSet, RiddleWidgetSet, \
     ShopWidgetSet, WorkbenchWidgetSet, TrainingsWidgetSet, ReachTargetWidgetSet
 from qrogue.management import StoryNarration
-from qrogue.util import achievements, common_messages, CheatConfig, Config, GameplayConfig, HelpText, \
+from qrogue.util import achievements, common_messages, CheatConfig, Config, GameplayConfig, UIConfig, HelpText, \
     HelpTextType, Logger, PathConfig, MapConfig, Controls, Keys, RandomManager
 from qrogue.util.config import FileTypes
 from qrogue.util.game_simulator import GameSimulator
@@ -39,7 +39,7 @@ class QrogueCUI(py_cui.PyCUI):
         except FileNotFoundError:
             Logger.instance().show_error(f"File \"{simulation_path}\" could not be found!")
 
-    def __init__(self, seed: int, width: int = 8, height: int = 9):
+    def __init__(self, seed: int, width: int = UIConfig.WINDOW_WIDTH, height: int = UIConfig.WINDOW_HEIGHT):
         super().__init__(width, height)
         self.set_title(f"Qrogue {Config.version()}")
         self.__controls = Controls(self._handle_key_presses)

--- a/qrogue/test/selection_tests.py
+++ b/qrogue/test/selection_tests.py
@@ -1,0 +1,33 @@
+from qrogue.test.test_util import DummySelectionWidget
+from qrogue.test import test_util as tu
+
+
+def test():
+    options = ["X Gate", "H Gate", "X Gate", "CX Gate",]# "Remove", "-Back-"]
+    sel = DummySelectionWidget(2, True, False)
+    sel.set_data(data=(
+        options,
+        [tu.true_callback] * len(options)
+    ))
+    sel.get_dummy_widget().selected = True
+
+    def render():
+        sel.render()
+        print(sel.widget.get_title())
+
+    while True:
+        render()
+        cin = input("")
+        if cin == "w":
+            sel.up()
+        elif cin == "d":
+            sel.right()
+        elif cin == "s":
+            sel.down()
+        elif cin == "a":
+            sel.left()
+        else:
+            break
+
+
+test()

--- a/qrogue/test/test_util.py
+++ b/qrogue/test/test_util.py
@@ -1,10 +1,19 @@
-from typing import List
+from typing import List, Callable, Any
 
 from qrogue.game.logic.actors import Robot, Enemy, Boss, Riddle
 from qrogue.game.logic.collectibles import ShopItem
 from qrogue.game.world.map import CallbackPack
 from qrogue.game.world.navigation import Direction
-from qrogue.util import RandomManager, Config, PathConfig, Logger
+from qrogue.graphics.widgets.my_widgets import WidgetWrapper, SelectionWidget
+from qrogue.util import RandomManager, Config, PathConfig, Logger, Controls
+
+
+def true_callback() -> bool:
+    return True
+
+
+def false_callback() -> bool:
+    return False
 
 
 def start_gp(args):
@@ -49,6 +58,13 @@ def error_popup(title: str, text: str):
     print("----------------------------------------")
 
 
+def get_dummy_controls(activate_printing: bool = False) -> Controls:
+    def handle_key_presses(key: int):
+        if activate_printing:
+            print(f"{key} was pressed")
+    return Controls(handle_key_presses)
+
+
 def init_singletons(seed: int = 7, include_config: bool = False, custom_data_path: str = None,
                     custom_user_path: str = None) -> bool:
     if include_config:
@@ -68,3 +84,53 @@ def init_singletons(seed: int = 7, include_config: bool = False, custom_data_pat
     CallbackPack(start_gp, start_fight, start_boss_fight, open_riddle, visit_shop, game_over)
 
     return True
+
+
+class DummyWidget(WidgetWrapper):
+    def __init__(self):
+        self.title = ""
+        self.selected = False
+
+    def is_selected(self):
+        return self.selected
+
+    def reposition(self, row: int = None, column: int = None, row_span: int = None, column_span: int = None):
+        pass
+
+    def add_text_color_rule(self, regex: str, color: int, rule_type: str, match_type: str = 'line',
+                            region: List[int] = [0, 1], include_whitespace: bool = False, selected_color=None) -> None:
+        pass
+
+    def activate_individual_coloring(self):
+        pass
+
+    def add_key_command(self, keys: List[int], command: Callable[[], Any]) -> Any:
+        pass
+
+    def set_title(self, title: str) -> None:
+        self.title = title
+
+    def get_title(self) -> str:
+        return self.title
+
+
+class DummySelectionWidget(SelectionWidget):
+    def __init__(self, columns: int, is_second: bool = False, stay_selected: bool = False, print_keys: bool = False):
+        self.__dummy_widget = DummyWidget()
+        super(DummySelectionWidget, self).__init__(self.__dummy_widget, get_dummy_controls(print_keys), columns, is_second,
+                                                   stay_selected)
+
+    def get_dummy_widget(self) -> DummyWidget:
+        return self.__dummy_widget
+
+    def up(self):
+        self._up()
+
+    def right(self):
+        self._right()
+
+    def down(self):
+        self._down()
+
+    def left(self):
+        self._left()

--- a/qrogue/util/__init__.py
+++ b/qrogue/util/__init__.py
@@ -1,6 +1,6 @@
 # exporting
 from .config import CheatConfig, ColorConfig, GameplayConfig, HudConfig, InstructionConfig, MapConfig, PathConfig, \
-    PopupConfig, Config, ShopConfig, QuantumSimulationConfig
+    PopupConfig, Config, ShopConfig, QuantumSimulationConfig, UIConfig
 from .controls import Controls, Keys
 from .help_texts import HelpText, HelpTextType
 from .logger import Logger

--- a/qrogue/util/__init__.py
+++ b/qrogue/util/__init__.py
@@ -1,6 +1,6 @@
 # exporting
 from .config import CheatConfig, ColorConfig, GameplayConfig, HudConfig, InstructionConfig, MapConfig, PathConfig, \
-    PopupConfig, Config, ShopConfig
+    PopupConfig, Config, ShopConfig, QuantumSimulationConfig
 from .controls import Controls, Keys
 from .help_texts import HelpText, HelpTextType
 from .logger import Logger

--- a/qrogue/util/achievements.py
+++ b/qrogue/util/achievements.py
@@ -67,7 +67,7 @@ class Achievement:
 
     def add_score(self, score: float):
         if score > 0:
-            self.__score += score
+            self.__score = min(self.score + score, self.done_score)
 
     def to_string(self) -> str:
         text = f"{self.name}{Achievement.__DATA_SEPARATOR}"
@@ -121,7 +121,10 @@ class AchievementManager:
             self.__temp_level_storage[name] = Achievement(name, AchievementType.Event, score, 1)
 
     def finished_tutorial(self, tutorial: str):
-        if tutorial not in self.__storage:
+        if tutorial in self.__storage:
+            tut = self.__storage[tutorial]
+            tut.add_score(tut.done_score)
+        else:
             self.__storage[tutorial] = Achievement(tutorial, AchievementType.Tutorial, 1, 1)
 
     def finished_level(self, level: str):

--- a/qrogue/util/common_messages.py
+++ b/qrogue/util/common_messages.py
@@ -73,6 +73,13 @@ def _no_space() -> str:
     return f"Your {circ} has {space} left. Remove a {gate} to place another one."
 
 
+def _no_gate_placed() -> str:
+    no = CC.highlight_word("no")
+    gate = CC.highlight_object("Gate")
+    circuit = CC.highlight_object("Circuit")
+    return f"Currently there is {no} {gate} in your {circuit} that you could remove!"
+
+
 class CommonPopups(Enum):
     SavingFailed = ("Error!", "Failed to save the game. Please make sure the folder for save data still exists and try "
                               "again.")
@@ -85,6 +92,7 @@ class CommonPopups(Enum):
     TutorialBlocked = ("Halt!", _tutorial_blocked())
     NotEnoughMoney = ("$$$", _not_enough_money())
     NoCircuitSpace = ("Nope", _no_space())
+    NoGatePlaced = ("Empty", _no_gate_placed())
 
     def __init__(self, title: str, text: str):
         self.__title = title

--- a/qrogue/util/config.py
+++ b/qrogue/util/config.py
@@ -648,6 +648,7 @@ class InstructionConfig:
 
 class QuantumSimulationConfig:
     DECIMALS = 3
+    MAX_SPACE_PER_NUMBER = 1 + 1 + 1 + DECIMALS     # sign + "0" + "." + DECIMALS
     TOLERANCE = 0.1
 
 

--- a/qrogue/util/config.py
+++ b/qrogue/util/config.py
@@ -262,6 +262,9 @@ class ColorCode(enum.Enum):
     KEY_HIGHLIGHT = "04"
     SPACESHIP_FLOOR = "70"
 
+    WRONG_AMPLITUDE = "90"
+    CORRECT_AMPLITUDE = "91"
+
     def __init__(self, code: str):
         self.__code = code
 
@@ -284,10 +287,12 @@ class ColorConfig:
     REGEX_TEXT_HIGHLIGHT = "//"     # regex recognizable version of TEXT_HIGHLIGHT (some characters need escaping)
     HIGHLIGHT_WIDTH = len(TEXT_HIGHLIGHT)
     __DIC = {
-        str(ColorCode.TILE_HIGHLIGHT): py_cui.WHITE_ON_BLACK,
-        str(ColorCode.OBJECT_HIGHLIGHT): py_cui.BLUE_ON_WHITE,
-        str(ColorCode.WORD_HIGHLIGHT): py_cui.RED_ON_WHITE,
-        str(ColorCode.KEY_HIGHLIGHT): py_cui.MAGENTA_ON_WHITE,
+        str(ColorCode.TILE_HIGHLIGHT):      py_cui.WHITE_ON_BLACK,
+        str(ColorCode.OBJECT_HIGHLIGHT):    py_cui.BLUE_ON_WHITE,
+        str(ColorCode.WORD_HIGHLIGHT):      py_cui.RED_ON_WHITE,
+        str(ColorCode.KEY_HIGHLIGHT):       py_cui.MAGENTA_ON_WHITE,
+        str(ColorCode.WRONG_AMPLITUDE):     py_cui.RED_ON_BLACK,
+        str(ColorCode.CORRECT_AMPLITUDE):   py_cui.GREEN_ON_BLACK,
     }
 
     @staticmethod
@@ -639,6 +644,11 @@ class MapConfig:
 
 class InstructionConfig:
     MAX_ABBREVIATION_LEN = 3
+
+
+class QuantumSimulationConfig:
+    DECIMALS = 3
+    TOLERANCE = 0.1
 
 
 class ShopConfig:

--- a/qrogue/util/config.py
+++ b/qrogue/util/config.py
@@ -1,4 +1,5 @@
 import enum
+import math
 import os
 import pathlib
 from datetime import datetime
@@ -279,7 +280,8 @@ class ColorConfig:
     STV_HEADING_COLOR = py_cui.CYAN_ON_BLACK
     CORRECT_AMPLITUDE_COLOR = py_cui.GREEN_ON_BLACK
     WRONG_AMPLITUDE_COLOR = py_cui.RED_ON_BLACK
-    CIRCUIT_COLOR = py_cui.CYAN_ON_BLACK
+    CIRCUIT_COLOR = py_cui.MAGENTA_ON_BLACK
+    CIRCUIT_LABEL_COLOR = py_cui.CYAN_ON_BLACK
     SPACESHIP_FLOOR_COLOR = py_cui.BLACK_ON_WHITE
 
     ERROR_COLOR = py_cui.RED_ON_BLUE
@@ -574,6 +576,40 @@ class GameplayConfig:
     @staticmethod
     def auto_swap_gates() -> bool:
         return GameplayConfig.__CONFIG[GameplayConfig.__AUTO_SWAP_GATES][0] == "True"
+
+
+class UIConfig:
+    WINDOW_WIDTH = 17
+    WINDOW_HEIGHT = 10
+
+    HUD_HEIGHT = 1
+    NON_HUD_HEIGHT = WINDOW_HEIGHT - HUD_HEIGHT
+    PAUSE_CHOICES_WIDTH = math.floor(WINDOW_WIDTH / 3)
+
+    MAIN_MENU_ROW = 2
+    MAIN_MENU_HEIGHT = round(WINDOW_HEIGHT / 2)
+    ASCII_ART_WIDTH = math.floor(2 * WINDOW_WIDTH / 3)
+
+    INPUT_STV_WIDTH = 1
+    OUTPUT_STV_WIDTH = 2
+    TARGET_STV_WIDTH = 3
+    STV_HEIGHT = math.floor(WINDOW_HEIGHT * 0.6)
+    DIALOG_HEIGHT = 2
+    PUZZLE_CHOICES_WIDTH = math.floor(WINDOW_WIDTH / 3)
+
+    SHOP_INVENTORY_WIDTH = 4
+    SHOP_DETAILS_HEIGHT = 1
+
+    @staticmethod
+    def stv_height(num_of_qubits: int) -> int:
+        if num_of_qubits == 1:
+            return 1
+        elif num_of_qubits == 2:
+            return 2
+        elif num_of_qubits == 3:
+            return 4
+        else:
+            return 6
 
 
 class HudConfig:

--- a/qrogue/util/config.py
+++ b/qrogue/util/config.py
@@ -590,7 +590,7 @@ class UIConfig:
     MAIN_MENU_HEIGHT = round(WINDOW_HEIGHT / 2)
     ASCII_ART_WIDTH = math.floor(2 * WINDOW_WIDTH / 3)
 
-    INPUT_STV_WIDTH = 1
+    INPUT_STV_WIDTH = 2
     OUTPUT_STV_WIDTH = 2
     TARGET_STV_WIDTH = 3
     STV_HEIGHT = math.floor(WINDOW_HEIGHT * 0.6)

--- a/qrogue/util/util_functions.py
+++ b/qrogue/util/util_functions.py
@@ -5,6 +5,30 @@ def is_power_of_2(n: int):
     return (n & (n - 1)) == 0
 
 
+def to_binary_string(num: int, digits: int = -1, msb: bool = True) -> str:
+    """
+    Converts a given integer into its binary representation as string.
+    :param num: the number we want to convert to a binary string
+    :param digits: number of digits the string should show (= length)
+    :param msb: whether to place the most or least significant bit(s) first
+    :return:
+    """
+    str_rep = ""
+    i = 0
+    while True:
+        str_rep += str(num % 2)
+        num = int(num / 2)
+        i += 1
+        if digits <= i:
+            break
+        elif digits < 0 and num <= 0:
+            break
+    if msb:
+        return str_rep[::-1]    # reverse the string
+    else:
+        return str_rep
+
+
 def center_string(text: str, line_width: int, uneven_left: bool = True, character: str = " ") -> str:
     """
     Prepends and appends the given character to the text in such a way that the text is centered as good as possible

--- a/qrogue/util/util_functions.py
+++ b/qrogue/util/util_functions.py
@@ -27,3 +27,13 @@ def center_string(text: str, line_width: int, uneven_left: bool = True, characte
         return half2 * character + text + half1 * character
     else:
         return half1 * character + text + half2 * character
+
+
+def align_string(text: str, line_width: int, left: bool = True, character: str = " ") -> str:
+    if line_width <= len(text):
+        return text
+    diff = line_width - len(text)
+    if left:
+        return text + diff * character
+    else:
+        return diff * character + text


### PR DESCRIPTION
Overhauled the Puzzle View (ReachTargetWidgetSets):
- Gates can now be placed in a grid based fashion instead of the sequential stepwise fashion before
- The whole multiplication (input vector * circuit matrix = output vector) is now shown 
- Changes to the circuit are now immediately commited but the penalty of wrong steps was removed
- Removed unused dialog options
- Widget positions are now dependent on the number of qubits