### PR TITLE
Tested on arch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,15 @@ to install Qrogue in your current Python environment.
 
 Afterwards you can launch the game simply by executing `qrogue` in the Python environment you installed Qrogue in.
 
+#### Alternative: pipenv ####
+
+If you want to keep your system environment clean, you may use `pipenv`:
+
+```bash
+pipenv install -e .
+pipenv run ./play_qrogue.sh
+```
+
 ### Windows ###
 
 #### Prerequisites ####

--- a/play_qrogue.sh
+++ b/play_qrogue.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-ENV_PATH=".env_qrogue"
+GAMEDATADIR=$(pwd)/qrogue/data
+USERDATADIR=$HOME/.local/share/qrogue
+[ -d ${USERDATADIR} ] || mkdir -p ${USERDATADIR}
+if [ ! -d ${GAMEDATADIR} ]
+then
+	echo Game data dir missing!
+	exit 1
+fi
 
-source ${ENV_PATH}/bin/activate
-python3 main.py --from-console $1
+python3 main.py --from-console -gd $GAMEDATADIR -ud $USERDATADIR $*
 

--- a/qrogue/game/logic/actors/state_vector.py
+++ b/qrogue/game/logic/actors/state_vector.py
@@ -1,4 +1,4 @@
-from collections import Iterator
+from collections.abc import Iterator
 from typing import List, Optional
 
 import numpy as np


### PR DESCRIPTION
Hi,

I tried this on an Arch Linux installation, I've added a few suggestions on how to make this run on a box with just Python 3.10 preinstalled.

If I just run it as suggested, I get:

```bash
$ pipenv run qrogue
/usr/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning: 1.0.1-9a8f2b8 is an invalid version and will not be supported in a future release
  warnings.warn(
[Errno 2] No such file or directory: '/home/fuero/dev/Qrogue/qrogue/util/config/../../data/qrogue_launch.config'
[Qrogue] Error #1:
qrogue.config is invalid. Please check if the second line describes a valid path (the path to your save files). Using special characters in the path could also cause this error so if the path is valid please consider using another one without special characters.

[Qrogue] Press ENTER to close the application
```

So I modified the `play_qrogue.sh` script slightly to pass the necessary paths to QRogue, create the userdata path if it doesn't exist and complain if the data path is missing.

Python 3.10 puts Iterators in collections.abc instead of collections

I prefer pipenv, so I added optional instructions on how to launch QRogue with it.